### PR TITLE
Repartition

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -24,6 +24,7 @@ import { Size } from "../utils/size";
 const links = [
   { icon: "home", url: "/", label: "Accueil" },
   { icon: "user", url: "/trombi", label: "Trombi" },
+  { icon: "zap", url: "/repartitions", label: "Repartitions" },
   { icon: "zap", url: "/associations", label: "Associations" },
   { icon: "check-square", url: "/sondages", label: "Sondages" },
 ];

--- a/frontend/src/components/repartitions/Anciens.tsx
+++ b/frontend/src/components/repartitions/Anciens.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import Container from "react-bootstrap/Container";
+import { authService } from "../../App";
+import { RepSidebar } from "./RepSidebar";
+import { PageTitle } from "../utils/PageTitle";
+
+export const Anciens =({
+  sidebarActions,
+}: {
+  sidebarActions?: any;
+}) => (
+  <Container className="mt-4">
+    <Row>
+      <Col md="3">
+        <RepSidebar isStaff={authService.isStaff} actions={sidebarActions} />
+      </Col>
+    </Row>
+  </Container>
+
+);

--- a/frontend/src/components/repartitions/Home.tsx
+++ b/frontend/src/components/repartitions/Home.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import Container from "react-bootstrap/Container";
+import { authService } from "../../App";
+import { PageTitle } from "../utils/PageTitle";
+import { RepSidebar } from "./RepSidebar";
+
+export const RepartitionsHome = ({
+  sidebarActions,
+}: {
+  sidebarActions?: any;
+}) => (
+  <Container className="mt-4">
+    <Row>
+      <Col md="3">
+        <RepSidebar isStaff={authService.isStaff} actions={sidebarActions} />
+      </Col>
+      <Col md="9"> 
+    <PageTitle>{"Bienvenue dans l'algorithme de répartition !"}</PageTitle>
+    </Col>
+    </Row>
+  </Container>
+
+);

--- a/frontend/src/components/repartitions/Nouveau.tsx
+++ b/frontend/src/components/repartitions/Nouveau.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import Container from "react-bootstrap/Container";
+import { authService } from "../../App";
+import { RepSidebar } from "./RepSidebar";
+import { PageTitle } from "../utils/PageTitle";
+
+export const Nouveau =({
+  sidebarActions,
+}: {
+  sidebarActions?: any;
+}) => (
+  <Container className="mt-4">
+    <Row>
+      <Col md="3">
+        <RepSidebar isStaff={authService.isStaff} actions={sidebarActions} />
+      </Col>
+    </Row>
+  </Container>
+
+);

--- a/frontend/src/components/repartitions/RepSidebar.tsx
+++ b/frontend/src/components/repartitions/RepSidebar.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import {
+  Sidebar,
+  SidebarItem,
+  SidebarSeparator,
+  SidebarSpace,
+} from "../utils/sidebar/Sidebar";
+
+export const RepSidebar = ({
+  isStaff,
+  actions,
+}: {
+  isStaff: boolean;
+  actions?: any;
+}) => (
+  <Sidebar title="Répartitions">
+    <SidebarItem icon="plus" to="/repartitions/nouveau">
+      Nouvelle répartition
+    </SidebarItem>
+    <SidebarItem icon="inbox" to="/repartitions/anciens">
+      Anciennes
+    </SidebarItem>
+    {actions && (
+      <>
+        <SidebarSeparator /> {actions}
+      </>
+    )}
+  </Sidebar>
+);

--- a/frontend/src/routing/global.ts
+++ b/frontend/src/routing/global.ts
@@ -2,6 +2,7 @@ import { Homepage } from "../components/Homepage";
 import { AssociationList } from "../components/associations/List";
 import { routes as usersRoutes } from "./users";
 import { routes as pollsRoutes } from "./polls";
+import { routes as repartitionsRoutes } from "./repartitions";
 import {
   compileAssociationRoutes,
   routes as associationsRoutes,
@@ -30,4 +31,5 @@ export const routes = [
     )
   )
   .concat(addRoutePrefix("/sondages", pollsRoutes))
+  .concat(addRoutePrefix("/repartitions", repartitionsRoutes))
   .concat(usersRoutes);

--- a/frontend/src/routing/repartitions.ts
+++ b/frontend/src/routing/repartitions.ts
@@ -1,0 +1,22 @@
+import { Route } from "./global";
+import { RepartitionsHome } from "../components/repartitions/Home";
+import { Nouveau } from "../components/repartitions/Nouveau";
+import { Anciens } from "../components/repartitions/Anciens";
+
+export const routes: Route[] = [
+{
+  path: "/Anciens",
+  component: Anciens,
+  exact: true,
+},
+{
+  path: "/Nouveau",
+  component: Nouveau,
+  exact: true,
+},
+  {
+    path: ``,
+    component: RepartitionsHome,
+    exact: true,
+  },
+];


### PR DESCRIPTION
Added a repartition page and two sidebar items. Would it be better to put a repartitions option on the "Trombi" page ?

![image](https://user-images.githubusercontent.com/48241379/85202520-2d0a1580-b307-11ea-8a1e-d857a52b5937.png)
