### PR TITLE
Add pre commit hooks for black and prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.9
+        exclude: frontend/
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: 5e374fda194d7f7ce9eebbd582b2a5594838c85b # Use the sha or tag you want to point at
+    hooks:
+      - id: prettier
+        files: frontend/


### PR DESCRIPTION
Prevent from committing if the black or prettier isn't happy. People will save time for them and for GitHub CIs
Please also review and test new instructions as https://github.com/Mines-Paristech-Students/Portail-des-eleves/wiki/Setting-up-the-project-locally#pre-commit-hooks