### PR TITLE
Fix marketplace and library update/creation when updating association

### DIFF
--- a/backend/associations/views/marketplace.py
+++ b/backend/associations/views/marketplace.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import mixins
 from rest_framework.viewsets import GenericViewSet
+from rest_framework.decorators import action
 
 from api.paginator import SmallResultsSetPagination
 from associations.models import Marketplace, Product, Transaction, Funding
@@ -43,10 +44,18 @@ class MarketplaceViewSet(viewsets.ModelViewSet):
     permission_classes = (MarketplacePermission,)
 
     def get_serializer_class(self):
-        if self.action in ("create", "update", "partial_update"):
+        if self.action in ("create", "update", "partial_update", "create_or_update"):
             return MarketplaceWriteSerializer
 
         return MarketplaceSerializer
+
+    @action(detail=False, methods=["PATCH"])
+    def create_or_update(self, request):
+        existing = Marketplace.objects.filter(pk=request.data["id"]).first()
+        if not existing:
+            return super(MarketplaceViewSet, self).create(request)
+        else:
+            return super(MarketplaceViewSet, self).update(request)
 
 
 class ProductFilter(TaggableFilter):

--- a/frontend/src/components/associations/settings/AssociationOptInSettings.tsx
+++ b/frontend/src/components/associations/settings/AssociationOptInSettings.tsx
@@ -20,7 +20,7 @@ export const AssociationOptInSettings = ({ association }) => (
           <EnableModuleForm
             id={association.id}
             label={"Magasin"}
-            apiMethod={api.marketplace.update}
+            apiMethod={api.marketplace.createOrUpdate}
             initialValue={association.enabledModules.includes("marketplace")}
           />
         </Col>
@@ -69,15 +69,14 @@ const EnableModuleForm = ({
   });
 
   return (
-    <label
-      onClick={() => {
-        save({ id: id, enabled: !checked });
-      }}
-    >
+    <label>
       <input
         type="checkbox"
         className="custom-switch-input"
         checked={checked}
+        onChange={() => {
+          save({ id: id, enabled: !checked, association: id, products: [] });
+        }}
       />
       <span className="custom-switch-indicator" />
       <span className="custom-switch-description">{label}</span>

--- a/frontend/src/services/api/marketplace.ts
+++ b/frontend/src/services/api/marketplace.ts
@@ -6,9 +6,9 @@ export const marketplace = {
     unwrap<Marketplace>(
       apiService.get(`/associations/marketplace/${marketplaceId}`)
     ),
-  update: ({ id, ...data }) =>
+  createOrUpdate: (data) =>
     unwrap<Marketplace>(
-      apiService.patch(`/associations/marketplace/${id}/`, data)
+      apiService.patch(`/associations/marketplace/create_or_update/`, data)
     ),
   balance: {
     get: (marketplaceId, customerId) =>


### PR DESCRIPTION
- On updating an association, the current checkboxes to enable/disable marketplace and library are not working.
- If the marketplace/library does not yet exists, it is created
- Otherwise, it is updated