### PR TITLE
Fix the use of naive datetime in ORM queries

### DIFF
--- a/backend/associations/views/event.py
+++ b/backend/associations/views/event.py
@@ -46,22 +46,25 @@ class EventFilter(FilterSet):
         # BEFORE is C) plus a number (the rank inside each partition).
         # Finally, order by `ordering`.
 
+        now_datetime = datetime.now().astimezone()
+
         now = (
             queryset.filter(
-                starts_at__lte=datetime.now(), ends_at__gte=datetime.now()
+                starts_at__lte=now_datetime,
+                ends_at__gte=now_datetime,
             ).order_by("-starts_at")
             if "NOW" in times
             else Event.objects.none()
         )
 
         after = (
-            queryset.filter(starts_at__gte=datetime.now()).order_by("starts_at")
+            queryset.filter(starts_at__gte=now_datetime).order_by("starts_at")
             if "AFTER" in times
             else Event.objects.none()
         )
 
         before = (
-            queryset.filter(ends_at__lte=datetime.now()).order_by("-starts_at")
+            queryset.filter(ends_at__lte=now_datetime).order_by("-starts_at")
             if "BEFORE" in times
             else Event.objects.none()
         )


### PR DESCRIPTION
Each time a query was made to fetch the events, this warning was thrown in the console logs :

```
/usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1427: RuntimeWarning: DateTimeField Event.ends_at received a naive datetime (2022-10-24 18:49:53.214774) while time zone support is active.
  RuntimeWarning)
```
